### PR TITLE
Fixed case#4 Longitude parsing and validation fails in specific cases

### DIFF
--- a/magellan.js
+++ b/magellan.js
@@ -18,12 +18,6 @@
     // Degrees minutes seconds format (e.g. 12°34'56" N or N12°34'56.123" )
     var DMS_FORMAT_REGEX = /^[NSEW]?\s*([+-]?\d{1,3})°?\s*(?:(\d{1,2}(?:\.\d+)?)[′'`]?\s*(?:(\d{1,2}(?:\.\d+)?)["″]?\s*)?)?\s*[NSEW]?$/;
     
-	// per http://stackoverflow.com/a/16696848/62937
-    function truncateNumber(numToTruncate, intDecimalPlaces) {
-        var numPower = Math.pow(10, intDecimalPlaces);
-        return ~~(numToTruncate * numPower)/numPower;
-    }   
-
     // Magellan factory
     function magellan() {
 		
@@ -61,28 +55,31 @@
 	            }
 	        } 
         
-	        // Handle function call when magellan( 123.4567 ) or similar
+			// Handle function call when magellan( 123.4567 ) or similar
 	        else if (args.length >= 1 && typeof args[0] == 'number') {
 
 	            // Degrees is the integer portion of the input
 	            coordinate.degrees = parseInt(args[0]);
             
 	            var decimal = Math.abs(parseFloat(args[0]) - coordinate.degrees);
-                var d60 = decimal * 60;
-                coordinate.minutes = parseInt(d60);
-                var m60 = (d60 - coordinate.minutes) * 60;
-	            var s60 = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
-				if(s60 == 60){
-	                s60 = truncateNumber(m60, 4);				
-				}
-                coordinate.seconds = s60;
-				
-				// var decimal = Math.abs(parseFloat(args[0]) - coordinate.degrees);
-	            // coordinate.minutes = parseInt(decimal * 60);
-				// var m60 = (d60 - coordinate.minutes) * 60;
-	            // coordinate.seconds = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
-	        } 
+	            coordinate.minutes = parseInt(decimal * 60);
+	            //coordinate.seconds = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
 
+				var x = ((decimal * 60) - coordinate.minutes) * 60;
+				if(x < 59.99995){
+		            coordinate.seconds = parseFloat((x).toFixed(4));					
+				}
+	            coordinate.seconds = parseFloat((x).toFixed(4));
+
+				if(coordinate.seconds == 60){
+					coordinate.seconds = 0;
+					coordinate.minutes +=1;
+					// if(coordinate.minutes == 60){
+					// 	coordinate.minutes = 0;
+					// 	coordinate.degrees += 1;
+					// }
+				}					
+			}		
 	        // Attempt to determine the direction if it was supplied
 	        if (typeof args[args.length - 1] === 'string') {
 	            var direction = args[args.length - 1].toUpperCase().match(/[NSEW]/);

--- a/magellan.js
+++ b/magellan.js
@@ -63,7 +63,6 @@
             
 	            var decimal = Math.abs(parseFloat(args[0]) - coordinate.degrees);
 	            coordinate.minutes = parseInt(decimal * 60);
-	            //coordinate.seconds = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
 
 				var x = ((decimal * 60) - coordinate.minutes) * 60;
 				if(x < 59.99995){
@@ -74,10 +73,10 @@
 				if(coordinate.seconds == 60){
 					coordinate.seconds = 0;
 					coordinate.minutes +=1;
-					// if(coordinate.minutes == 60){
-					// 	coordinate.minutes = 0;
-					// 	coordinate.degrees += 1;
-					// }
+					if(coordinate.minutes == 60){
+						coordinate.minutes = 0;
+						coordinate.degrees += 1;
+					}
 				}					
 			}		
 	        // Attempt to determine the direction if it was supplied

--- a/magellan.js
+++ b/magellan.js
@@ -18,6 +18,12 @@
     // Degrees minutes seconds format (e.g. 12°34'56" N or N12°34'56.123" )
     var DMS_FORMAT_REGEX = /^[NSEW]?\s*([+-]?\d{1,3})°?\s*(?:(\d{1,2}(?:\.\d+)?)[′'`]?\s*(?:(\d{1,2}(?:\.\d+)?)["″]?\s*)?)?\s*[NSEW]?$/;
     
+	// per http://stackoverflow.com/a/16696848/62937
+    function truncateNumber(numToTruncate, intDecimalPlaces) {
+        var numPower = Math.pow(10, intDecimalPlaces);
+        return ~~(numToTruncate * numPower)/numPower;
+    }   
+
     // Magellan factory
     function magellan() {
 		
@@ -62,8 +68,19 @@
 	            coordinate.degrees = parseInt(args[0]);
             
 	            var decimal = Math.abs(parseFloat(args[0]) - coordinate.degrees);
-	            coordinate.minutes = parseInt(decimal * 60);
-	            coordinate.seconds = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
+                var d60 = decimal * 60;
+                coordinate.minutes = parseInt(d60);
+                var m60 = (d60 - coordinate.minutes) * 60;
+	            var s60 = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
+				if(s60 == 60){
+	                s60 = truncateNumber(m60, 4);				
+				}
+                coordinate.seconds = s60;
+				
+				// var decimal = Math.abs(parseFloat(args[0]) - coordinate.degrees);
+	            // coordinate.minutes = parseInt(decimal * 60);
+				// var m60 = (d60 - coordinate.minutes) * 60;
+	            // coordinate.seconds = parseFloat((((decimal * 60) - coordinate.minutes) * 60).toFixed(4));
 	        } 
 
 	        // Attempt to determine the direction if it was supplied

--- a/test/suite.js
+++ b/test/suite.js
@@ -89,3 +89,5 @@ assert.equal('12.300000', magellan(12.3).toDD())
 assert.equal('12° 20\' 44.1600" S', magellan(-12.3456).latitude().toDMS(' '))
 
 
+/* BUGFIX for CASE #4: Longitude parsing and validation fails in specific cases */
+assert.notEqual(null, magellan(-120.1).longitude(), 'Fails with BUG described in CASE#4');

--- a/test/suite.js
+++ b/test/suite.js
@@ -11,6 +11,9 @@ assert.notDeepEqual(x.coordinate, y.coordinate)
 // must get the same result when coverting between formats consecutively
 assert.equal('123.456700', magellan(magellan(123.4567).toDMS()).toDD())
 assert.equal('123°27\'24.1200"W', magellan(magellan(-123.4567).longitude().toDMS()).toDMS())
+assert.equal('19°39\'0.0000"E', magellan(19.6500).longitude().toDMS())
+assert.equal('19°38\'59.9999"E', magellan(19.64999997).longitude().toDMS())
+assert.equal('19°59\'59.9999"E', magellan(19.99999997).longitude().toDMS())
 assert.equal('12.345600', magellan(magellan(12.3456).toDMS(' ')).toDD())
 
 /* VERSION */

--- a/test/suite.js
+++ b/test/suite.js
@@ -14,6 +14,7 @@ assert.equal('123°27\'24.1200"W', magellan(magellan(-123.4567).longitude().toDM
 assert.equal('19°39\'0.0000"E', magellan(19.6500).longitude().toDMS())
 assert.equal('19°38\'59.9999"E', magellan(19.64999997).longitude().toDMS())
 assert.equal('19°59\'59.9999"E', magellan(19.99999997).longitude().toDMS())
+assert.equal('20°0\'0.0000"E', magellan(19.99999999).longitude().toDMS())
 assert.equal('12.345600', magellan(magellan(12.3456).toDMS(' ')).toDD())
 
 /* VERSION */


### PR DESCRIPTION
Hi!

I came across the same bug that @markerikson reported. (Case#4)

Mark's fix would break the some of the Idempotency test rules for 59.9999 seconds, so i have instead added a few checks when setting the minutes and seconds.
