### PR TITLE
Added bower.json and corrected version no.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "magellan",
+  "main": "magellan.js",
+  "version": "1.0.5",
+  "homepage": "https://github.com/dbarbalato/magellan",
+  "authors": [
+    "Dave Barbalato"
+  ],
+  "description": "JavaScript Latitude and Longitude Validation and Formatting",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "lattitude",
+    "longitude",
+    "lat",
+    "lon",
+    "geographical",
+    "coordinates"
+  ],
+  "license": "unknown",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/magellan.js
+++ b/magellan.js
@@ -1,10 +1,10 @@
-// Magellan version 1.0.2
+// Magellan version 1.0.5
 // Provided by Dave Barbalato - https://github.com/dbarbalato/
 // Distributable under the MIT License
 ;(function() {
 
     // Version identifier
-    var VERSION = '1.0.2';
+    var VERSION = '1.0.5';
 
     // Compass direction constants
     var NORTH = 'N';

--- a/test/suite.js
+++ b/test/suite.js
@@ -20,7 +20,7 @@ assert.equal('12.345600', magellan(magellan(12.3456).toDMS(' ')).toDD())
 /* VERSION */
 
 // magellan must correctly expose its version
-assert.equal('1.0.2', magellan.version)
+assert.equal('1.0.5', magellan.version)
 
 /* PARSING */
 


### PR DESCRIPTION
I'm using magellan.js in the browser, and I'd rather fetch it from bower than npm to better integrate with my workflow.
Will you please consider making the current version (1.0.5) a release as well, since this being wrong stops the correct version being downloaded by bower. (Last release is 1.0.2 dated 2013.)