### PR TITLE
Updated Input Parsing

### DIFF
--- a/magellan.js
+++ b/magellan.js
@@ -13,11 +13,11 @@
 
     // Signed degree format (e.g. -123.45)
     var DD_FORMAT_REGEX = /^([+-]?\d{1,3})(.\d+)?$/;
-
+    // contains symbols indicating not a signed degree format
+    var NOT_DD_FORMAT_REGEX = /\S[\s′'`"″\u00B0]\S/;
     // Degrees minutes seconds format (e.g. 12°34'56" N or N12°34'56.123" )
     var DMS_FORMAT_REGEX = /^[NSEW]?\s*([+-]?\d{1,3})°?\s*(?:(\d{1,2}(?:\.\d+)?)[′'`]?\s*(?:(\d{1,2}(?:\.\d+)?)["″]?\s*)?)?\s*[NSEW]?$/;
 
-    var NOT_DD_FORMAT_REGEX = /\S[\s′'`"″\u00B0]\S/;
     // Magellan factory
     function magellan() {
 
@@ -42,7 +42,7 @@
 	            var matches;
 
 	            //  Attempt to match against Decimal Degrees format
-	            if (((matches = args[0].match(DD_FORMAT_REGEX)) != null) && !NOT_DD_FORMAT_REGEX.exec(args[0])) {
+	            if (!NOT_DD_FORMAT_REGEX.exec(args[0]) && ((matches = args[0].match(DD_FORMAT_REGEX)) != null)) {
 	                coordinate.degrees = parseInt(matches[1]);
 	                var decimal = parseFloat(matches[2]) || 0.0;
 	                coordinate.minutes = parseInt(decimal * 60);

--- a/magellan.js
+++ b/magellan.js
@@ -17,6 +17,7 @@
     // Degrees minutes seconds format (e.g. 12°34'56" N or N12°34'56.123" )
     var DMS_FORMAT_REGEX = /^[NSEW]?\s*([+-]?\d{1,3})°?\s*(?:(\d{1,2}(?:\.\d+)?)[′'`]?\s*(?:(\d{1,2}(?:\.\d+)?)["″]?\s*)?)?\s*[NSEW]?$/;
 
+    var NOT_DD_FORMAT_REGEX = /\S[\s′'`"″\u00B0]\S/;
     // Magellan factory
     function magellan() {
 
@@ -41,9 +42,8 @@
 	            var matches;
 
 	            //  Attempt to match against Decimal Degrees format
-	            if ((matches = args[0].match(DD_FORMAT_REGEX)) != null) {
+	            if (((matches = args[0].match(DD_FORMAT_REGEX)) != null) && !NOT_DD_FORMAT_REGEX.exec(args[0])) {
 	                coordinate.degrees = parseInt(matches[1]);
-
 	                var decimal = parseFloat(matches[2]) || 0.0;
 	                coordinate.minutes = parseInt(decimal * 60);
 	                coordinate.seconds = parseFloat(((decimal * 60) - coordinate.minutes) * 60);
@@ -123,8 +123,8 @@
 	            // Limit the precision to 4 decimal places
 	            formatted = formatted.toFixed(6);
 
+	            if (coordinate.direction && (coordinate.direction == SOUTH || coordinate.direction == WEST) && decimal >= 0) formatted = '-' + formatted;
 
-	            if (coordinate.direction && (coordinate.direction == SOUTH || coordinate.direction == WEST) && decimal > 0) formatted = '-' + formatted;
 	            else if (!coordinate.direction && isPositive === false && decimal > 0) formatted = '-' + formatted;
 
 	            return formatted;

--- a/test/suite.js
+++ b/test/suite.js
@@ -101,9 +101,15 @@ assert.equal('123°27\'21.6000"E', magellan(123.456).longitude().toDMS())
 assert.equal('123.456000', magellan('123°27\'21.6"E').toDD())
 assert.equal('123.456000', magellan('123°27\'21.6"').longitude().toDD())
 assert.equal('-123.000000', magellan(-123).toDD())
+assert.equal('-12.000000', magellan('-12').latitude().toDD())
+assert.equal('-12.000000', magellan('12S').toDD())
 assert.equal('123°27\'21.6000"W', magellan(-123.456).longitude().toDMS())
 assert.equal('12.300000', magellan(12.3).toDD())
 assert.equal('12° 20\' 44.1600" S', magellan(-12.3456).latitude().toDMS(' '))
+assert.equal('12.050000', magellan('12 3').toDD())
+assert.equal('12.050000', magellan('12 03').toDD())
+assert.equal('12.050000', magellan('12°3').toDD())
+
 
 
 /* BUGFIX for CASE #4: Longitude parsing and validation fails in specific cases */

--- a/test/suite.js
+++ b/test/suite.js
@@ -101,7 +101,6 @@ assert.equal('123°27\'21.6000"E', magellan(123.456).longitude().toDMS())
 assert.equal('123.456000', magellan('123°27\'21.6"E').toDD())
 assert.equal('123.456000', magellan('123°27\'21.6"').longitude().toDD())
 assert.equal('-123.000000', magellan(-123).toDD())
-assert.equal('-12.000000', magellan('12S').toDD())
 assert.equal('123°27\'21.6000"W', magellan(-123.456).longitude().toDMS())
 assert.equal('12.300000', magellan(12.3).toDD())
 assert.equal('12° 20\' 44.1600" S', magellan(-12.3456).latitude().toDMS(' '))
@@ -109,6 +108,7 @@ assert.equal('12.050000', magellan('12 3').toDD())
 assert.equal('12.050000', magellan('12 03').toDD())
 assert.equal('12.050000', magellan('12°3').toDD())
 assert.equal('-12.000000', magellan('-12').latitude().toDD())
+assert.equal('-12.000000', magellan('12S').toDD())
 
 
 /* BUGFIX for CASE #4: Longitude parsing and validation fails in specific cases */

--- a/test/suite.js
+++ b/test/suite.js
@@ -101,7 +101,6 @@ assert.equal('123°27\'21.6000"E', magellan(123.456).longitude().toDMS())
 assert.equal('123.456000', magellan('123°27\'21.6"E').toDD())
 assert.equal('123.456000', magellan('123°27\'21.6"').longitude().toDD())
 assert.equal('-123.000000', magellan(-123).toDD())
-assert.equal('-12.000000', magellan('-12').latitude().toDD())
 assert.equal('-12.000000', magellan('12S').toDD())
 assert.equal('123°27\'21.6000"W', magellan(-123.456).longitude().toDMS())
 assert.equal('12.300000', magellan(12.3).toDD())
@@ -109,7 +108,7 @@ assert.equal('12° 20\' 44.1600" S', magellan(-12.3456).latitude().toDMS(' '))
 assert.equal('12.050000', magellan('12 3').toDD())
 assert.equal('12.050000', magellan('12 03').toDD())
 assert.equal('12.050000', magellan('12°3').toDD())
-
+assert.equal('-12.000000', magellan('-12').latitude().toDD())
 
 
 /* BUGFIX for CASE #4: Longitude parsing and validation fails in specific cases */


### PR DESCRIPTION
Hi,

I recently implemented magellan to parse user lat-long inputs for a [marine-mammal citizen science platform](http://www.happywhale.com) I am working on. Our director (a whale guy) was not happy with the input parsing in certain edge cases so I added a few lines to address those cases. The cases in particular were: 
- Space or symbol separated DMD inputs without a decimal such as  `magellan('12 3')`, `magellan('12 30')`, or `magellan('12°3')` were parsing as decimal degrees to incorrect values. To address this I added an extra regex looking for symbol patterns indicating that parsing should skip over the DD phase to the DMS/DMD phase. 
- The `.toDD()` method was ignoring direction if the decimal evaluated to zero such that `magellan('-12').latitude().toDD()` and `magellan('12S').toDD()` both evaluated to 12.0000. This I addressed just by changing the condition for adding a negative sign.

I hope you find these changes helpful. Thanks for the awesome work! We were looking for a way to automatically allow different lat/long formats your package has been a great solution.
